### PR TITLE
dropping precision when rounding to int

### DIFF
--- a/payment_paysera/paysera.py
+++ b/payment_paysera/paysera.py
@@ -142,4 +142,4 @@ def get_form_values(value_dict, sign_password):
 
 def get_amount_string(currency, amount):
     currency.ensure_one()
-    return str(int(currency.round(amount) / currency.rounding))
+    return str(int(currency.round(currency.round(amount) / currency.rounding)))


### PR DESCRIPTION
we had encountered a case where the amount on the acquirer (Paysera) had
a different amount than in a transaction (by 1 cent).

This stringified amount is actually used for posting the amount and the
final int rounding always rounds down so if the division by
currency.rounding lands on the lower side the whole amount differes by
the smallest currency amount. I.e.:
```
amount = str(int(316.46 / 0.01))  # 31645, while it should be 31646
```