### PR TITLE
change redirect url after accepting

### DIFF
--- a/payment_paysera/controllers/main.py
+++ b/payment_paysera/controllers/main.py
@@ -29,7 +29,7 @@ class PayseraController(http.Controller):
         except Exception:
             _LOG.exception('Error while validating Paysera accept callback.')
 
-        return werkzeug.utils.redirect('/shop/payment/validate')
+        return werkzeug.utils.redirect('/payment/process')
 
     @http.route([
         '/payment/paysera/cancel',


### PR DESCRIPTION
Seems like `/shop/payment/validate` won't work because it only validates
the transaction and does not trigger the confirmation via
`transaction._post_process_after_done()` (see https://git.io/JvH0Y)

From what I've checked it seems like `/payment/process` is more standard
and includes some retry behavior in case of psycopg2.OperationalErrors

Attempted to change the `return_url` in [tests/test_paysera.py:39](https://github.com/naglis/misc-addons/blob/2e7c0f63d6c62e856887662fff0beddef2e26ec8/payment_paysera/tests/test_paysera.py#L39), but would need to set up the whole integration again to regenerate SS2 key. Do you think its worth it?